### PR TITLE
Scope whole section header `meta.section`

### DIFF
--- a/Git Formats/Git Common.sublime-syntax
+++ b/Git Formats/Git Common.sublime-syntax
@@ -63,14 +63,6 @@ contexts:
       captures:
         1: punctuation.definition.comment.git
 
-  comments-section-line:
-    # comment which is at the end of a section line
-    - match: \s*(({{comment_char}}).*\n?)?$
-      scope: meta.whitespace.newline.git
-      captures:
-        1: comment.line.git
-        2: punctuation.definition.comment.git
-
 ##[ REFERENCES ]#######################################################
 
   references:

--- a/Git Formats/Git Config - Fold.tmPreferences
+++ b/Git Formats/Git Config - Fold.tmPreferences
@@ -9,9 +9,9 @@
         <array>
             <dict>
                 <key>begin</key>
-                <string>meta.section punctuation.definition.section.end</string>
+                <string>meta.section meta.brackets punctuation.definition.brackets.end</string>
                 <key>end</key>
-                <string>meta.section punctuation.definition.section.begin</string>
+                <string>meta.section meta.brackets punctuation.definition.brackets.begin</string>
                 <key>excludeTrailingNewlines</key>
                 <true/>
             </dict>

--- a/Git Formats/Git Config - Symbol List.tmPreferences
+++ b/Git Formats/Git Config - Symbol List.tmPreferences
@@ -4,7 +4,7 @@
 	<key>name</key>
 	<string>Symbol List</string>
 	<key>scope</key>
-	<string>meta.brackets.git.config</string>
+	<string>meta.section.header.git.config meta.brackets.git.config</string>
 	<key>settings</key>
 	<dict>
 		<key>showInSymbolList</key>

--- a/Git Formats/Git Config.sublime-syntax
+++ b/Git Formats/Git Config.sublime-syntax
@@ -40,17 +40,21 @@ contexts:
 
   section-header:
     - match: \[
-      scope: punctuation.definition.section.begin.git.config
-      set: [expect-line-end, section-header-end, section-name]
+      scope: punctuation.definition.brackets.begin.git.config
+      set: [section-header-meta, section-header-end, section-name]
+
+  section-header-meta:
+    - meta_scope: meta.section.header.git.config
+    - match: $\n?
+      pop: 1
+    - match: \S
+      scope: invalid.illegal.expected.eol.git.config
 
   section-header-end:
-    - meta_scope: meta.section.git.config
+    - meta_scope: meta.brackets.git.config
     - match: \]
-      scope: punctuation.definition.section.end.git.config
-      set:
-        - include: Git Common.sublime-syntax#comments-section-line
-        - match: ''
-          pop: 1
+      scope: punctuation.definition.brackets.end.git.config
+      pop: 1
     - include: illegal-line-end-pop
     - match: \S
       scope: invalid.illegal.header-end.git.config
@@ -109,6 +113,7 @@ contexts:
   # changed = red
   # untracked = bold green
   key-color-pair:
+    - meta_scope: meta.section.body.git.config
     - match: ^(\s*)({{variable_name}})(\s*(\=)\s*)
       captures:
         1: meta.mapping.git.config
@@ -123,6 +128,7 @@ contexts:
 
   # key = val
   key-value-pair:
+    - meta_scope: meta.section.body.git.config
     - match: ^(\s*)({{variable_name}})(\s*(\=)\s*)
       captures:
         1: meta.mapping.git.config

--- a/Git Formats/tests/syntax_test_git_config
+++ b/Git Formats/tests/syntax_test_git_config
@@ -10,24 +10,24 @@
 
 # SECTION HEADER TESTS
 [section]  # color section
-# <- meta.section punctuation.definition.section.begin
-#^^^^^^^ meta.section entity.name
-#       ^ meta.section punctuation.definition.section.end
-#        ^ meta.whitespace.newline
-#        ^^^^^^^^^^^^^^^^^^ meta.whitespace.newline
+# <- meta.section.header meta.brackets punctuation.definition.brackets.begin
+#^^^^^^^ meta.section.header meta.brackets entity.name.section - punctuation
+#       ^ meta.section.header meta.brackets punctuation.definition.brackets.end
+#        ^^^^^^^^^^^^^^^^^^ meta.section.header - meta.brackets
 #          ^ punctuation.definition.comment
 #          ^^^^^^^^^^^^^^^^ comment.line
 [section "subsection"]
-# <- meta.section punctuation.definition.section.begin
-#^^^^^^^^^^^^^ meta.section
+# <- meta.section.header meta.brackets punctuation.definition.brackets.begin
+#^^^^^^^^^^^^^^^^^^^^^ meta.section.header meta.brackets
+#                     ^ meta.section.header - meta.brackets
 #^^^^^^^ entity.name
 #        ^^^^^^^^^^^^ string.quoted.double
 #        ^ punctuation.definition.string.begin
 #                   ^ punctuation.definition.string.end
-#                    ^ punctuation.definition.section.end
+#                    ^ punctuation.definition.brackets.end
 [section \"subsection"]
-# <- meta.section punctuation.definition.section.begin
-#^^^^^^^^^^^^^ meta.section
+# <- meta.section.header meta.brackets punctuation.definition.brackets.begin
+#^^^^^^^^^^^^^ meta.section.header
 #^^^^^^^ entity.name
 #        ^ invalid.illegal
 [section "\slashes\are\legal"]
@@ -55,23 +55,23 @@
 
 # LEGACY SECTION HEADER SYNTAX
 [section.subsection.subsubsection]
-# <- meta.section
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.section
-#                                 ^ - meta.section
-# <- punctuation.definition.section.begin
+# <- meta.section.header
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.section.header meta.brackets
+#                                 ^ meta.section.header - meta.brackets
+# <- punctuation.definition.brackets.begin
 #^^^^^^^ entity.name.section
 #       ^ punctuation.accessor.dot
 #        ^^^^^^^^^^ string.unquoted
 #                  ^ punctuation.accessor.dot
 #                   ^^^^^^^^^^^^^ string.unquoted
-#                                ^ punctuation.definition.section.end
+#                                ^ punctuation.definition.brackets.end
 
 # LEGACY SECTION HEADER SYNTAX
 [se\ct\\ion.s"ub\se\\ct\"ion
-# <- meta.section
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.section
-#                            ^ - meta.section
-# <- punctuation.definition.section.begin
+# <- meta.section.header
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.section.header
+#                            ^ - meta.section.header
+# <- punctuation.definition.brackets.begin
 #^^ entity.name.section
 #  ^ invalid.illegal.section-name
 #   ^^ entity.name.section
@@ -91,13 +91,13 @@
 
 # COLOR TESTS
 [color "diff"]
-# <- meta.section punctuation.definition.section.begin
-#^^^^^^^^^^^^^ meta.section
+# <- meta.section.header meta.brackets punctuation.definition.brackets.begin
+#^^^^^^^^^^^^^ meta.section.header
 #^^^^^ entity.name
 #      ^^^^^^ string.quoted.double
 #      ^ punctuation.definition.string.begin
 #           ^ punctuation.definition.string.end
-#            ^ punctuation.definition.section.end
+#            ^ punctuation.definition.brackets.end
     old = red
 # <- meta.mapping
 #^^^^^^^^^^^^ meta.mapping
@@ -214,7 +214,7 @@
 
 # ILLEGAL NEWLINE IN SECTION TEST
 [section
-#^^^^^^^^ meta.section
+#^^^^^^^^ meta.section.header
 #^^^^^^^ entity.name
 #       ^ invalid.illegal.unexpected.eol
 ]
@@ -456,10 +456,10 @@ stray-bracket]
 
 # REAL WORLD SAMPLE TESTS
 [alias]
-# <- meta.section punctuation.definition.section.begin
-#^^^^^^ meta.section
+# <- meta.section.header meta.brackets punctuation.definition.brackets.begin
+#^^^^^^ meta.section.header
 #^^^^^ entity.name
-#     ^ punctuation.definition.section.end
+#     ^ punctuation.definition.brackets.end
     branch-author = for-each-ref --format='%(committerdate) %09 %(authorname) %09 %(refname)'
 # <- meta.mapping
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.mapping


### PR DESCRIPTION
What do you think about something like that?

1. Adding a dedicated `section-header-meta` context to replace `expect-line-end` and to
2. scope the whole `[name] # comment` line `meta.section.header`
3. while re-adding `meta.brackets` for `[name]` part. _Removing it broke symbol list btw._
4. add a corresponding `meta.section.body` to the key-value pairs

INI/GitConfig files are organized line-wise. As nothing is allowed to follow the `[...]` part, it should be ok to scope the whole line as such. Color scheme can now just address `meta.section.header` to manipulate whole line's background.

Comments are scoped via prototype. So additions to Git Common are not required.