### PR TITLE
[PHP] Add typed constants

### DIFF
--- a/PHP/PHP Source.sublime-syntax
+++ b/PHP/PHP Source.sublime-syntax
@@ -921,12 +921,44 @@ contexts:
   constant-declarations:
     - match: (?i:const)\b
       scope: keyword.declaration.constant.php
-      push: constant-declaration-name
+      push: constant-declaration-body
+
+  constant-declaration-body:
+    - include: attributes
+    - include: comments
+    - match: (?=\S)
+      branch_point: constant-declaration
+      branch:
+        - untyped-constant-declaration
+        - typed-constant-declaration
+      pop: 1
+
+  untyped-constant-declaration:
+    - match: '{{guarded_identifier}}'
+      scope: entity.name.constant.php
+      set: untyped-constant-declaration-check
+    - match: (?=\S)
+      fail: constant-declaration
+
+  untyped-constant-declaration-check:
+    - include: comments
+    - match: (?=[=;}]|{{access_modifier}}|{{property_modifier}}|{{static_modifier}})
+      pop: 1
+    - match: (?=\S)
+      fail: constant-declaration
+
+  typed-constant-declaration:
+    - meta_include_prototype: false
+    - match: ''
+      set:
+        - constant-declaration-name
+        - type-hint-body
+        - type-hint-simple-type
 
   constant-declaration-name:
     - match: '{{guarded_identifier}}'
       scope: entity.name.constant.php
-      set: nested-expressions
+      pop: 1
     - include: attributes
     - include: comments
     - include: else-pop

--- a/PHP/tests/syntax_test_php.php
+++ b/PHP/tests/syntax_test_php.php
@@ -1382,6 +1382,22 @@ class B
 //   ^^^^^^^^^^^^^^^^^^ meta.class.php meta.block.php - meta.use
 //    ^ storage.modifier
 
+    public const STR_1
+//  ^^^^^^ storage.modifier
+//         ^^^^^ keyword.declaration.constant.php
+//               ^^^^^ entity.name.constant.php
+
+    public
+//  ^^^^^^ storage.modifier
+      const
+//    ^^^^^ keyword.declaration.constant.php
+      STR_1
+//    ^^^^^ entity.name.constant.php
+      =
+//    ^ keyword.operator.assignment.php
+      '';
+//    ^^ string.quoted.single.php
+
     public const STR_1 = '';
 //  ^^^^^^ storage.modifier
 //         ^^^^^ keyword.declaration.constant.php
@@ -1400,6 +1416,79 @@ class B
 //                     ^^^^^ entity.name.constant.php
 //                           ^ keyword.operator.assignment
 //                             ^^^^^ support.function.array.php
+
+    // typed class constants
+
+    private const int A
+//  ^^^^^^^ storage.modifier.access.php
+//          ^^^^^ keyword.declaration.constant.php
+//                ^^^ meta.type.php storage.type.primitive.php
+//                    ^ entity.name.constant.php
+
+    private const int A = 1;
+//  ^^^^^^^ storage.modifier.access.php
+//          ^^^^^ keyword.declaration.constant.php
+//                ^^^ meta.type.php storage.type.primitive.php
+//                    ^ entity.name.constant.php
+//                      ^ keyword.operator.assignment.php
+//                        ^ constant.numeric.value.php
+//                         ^ punctuation.terminator.statement.php
+
+    public const mixed B = 1;
+//  ^^^^^^ storage.modifier.access.php
+//         ^^^^^ keyword.declaration.constant.php
+//               ^^^^^ meta.type.php storage.type.primitive.php
+//                     ^ entity.name.constant.php
+//                       ^ keyword.operator.assignment.php
+//                         ^ constant.numeric.value.php
+//                          ^ punctuation.terminator.statement.php
+
+    public
+//  ^^^^^^ storage.modifier.access.php
+      const
+//    ^^^^^ keyword.declaration.constant.php
+      mixed
+//    ^^^^^ meta.type.php storage.type.primitive.php
+      B
+//    ^ entity.name.constant.php
+      =
+//    ^ keyword.operator.assignment.php
+      1;
+//    ^ constant.numeric.value.php
+//     ^ punctuation.terminator.statement.php
+
+    public const Foo|Stringable|null D = null;
+//  ^^^^^^ storage.modifier.access.php
+//         ^^^^^ keyword.declaration.constant.php
+//               ^^^^^^^^^^^^^^^^^^^ meta.block.php meta.type.php
+//               ^^^ support.class.php
+//                  ^ punctuation.separator.type.union.php
+//                   ^^^^^^^^^^ support.class.builtin.php
+//                             ^ punctuation.separator.type.union.php
+//                              ^^^^ storage.type.primitive.php
+//                                   ^ entity.name.constant.php
+//                                     ^ keyword.operator.assignment.php
+//                                       ^^^^ constant.language.null.php
+//                                           ^ punctuation.terminator.statement.php
+
+    public
+//  ^^^^^^ storage.modifier.access.php
+      const
+//    ^^^^^ keyword.declaration.constant.php
+      Foo|Stringable|null
+//    ^^^^^^^^^^^^^^^^^^^ meta.block.php meta.type.php
+//    ^^^ support.class.php
+//       ^ punctuation.separator.type.union.php
+//        ^^^^^^^^^^ support.class.builtin.php
+//                  ^ punctuation.separator.type.union.php
+//                   ^^^^ storage.type.primitive.php
+      D
+//    ^ entity.name.constant.php
+      =
+//    ^ keyword.operator.assignment.php
+      null;
+//    ^^^^ constant.language.null.php
+//        ^ punctuation.terminator.statement.php
 
     public function __construct(
         public readonly int $val = 1


### PR DESCRIPTION
This PR proposes a solution for typed constants.

It uses branching to distinguish typed and untyped constant declarations to workaround ST's line blindness, so any kind of multi-line declaration is handled correctly.